### PR TITLE
add: Search by free text.

### DIFF
--- a/ds.enovia.common/ds.enovia.common.csproj
+++ b/ds.enovia.common/ds.enovia.common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.9</Version>
+    <Version>2.0.10</Version>
     <Authors>Dassault Systèmes - EMED CPE</Authors>
     <Company>Dassault Systèmes</Company>
     <Description>3DEXPERIENCE Dotnet Core SDK for Enovia (shared base) web services</Description>

--- a/ds.enovia.common/search/SearchByFreeText.cs
+++ b/ds.enovia.common/search/SearchByFreeText.cs
@@ -1,0 +1,37 @@
+﻿//------------------------------------------------------------------------------------------------------------------------------------
+// Copyright 2022 Dassault Systèmes - CPE EMED
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----
+
+namespace ds.enovia.common.search
+{
+    // Allows integration of more complex logic with the Search Services in form of free text.
+    // There is no syntax validation on the free text.
+    // It is up to the caller to make sure it corresponds to valid UQL syntax.
+    // The free text should not be URLencoded this is responsibility of the service.
+    public class SearchByFreeText : SearchQuery
+    {
+        public SearchByFreeText(string _text)
+        {
+            Text = _text;
+        }
+
+        public string Text { get; private set; }
+
+        public override string GetSearchString()
+        {
+            return Text;
+        }
+    }
+}


### PR DESCRIPTION
Allows integration of more complex logic with the Search Services in form of free text.
There is no syntax validation on the free text.
It is up to the caller to make sure it corresponds to valid UQL syntax.
The free text should not be URLencoded this is responsibility of the service.